### PR TITLE
[CCXDEV-9225] Add CI/CD

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -exv
+
+IMAGE="quay.io/cloudservices/insights-content-template-renderer"
+IMAGE_TAG=$(git rev-parse --short=7 HEAD)
+
+if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
+    echo "QUAY_USER and QUAY_TOKEN must be set"
+    exit 1
+fi
+
+if [[ -z "$RH_REGISTRY_USER" || -z "$RH_REGISTRY_TOKEN" ]]; then
+    echo "RH_REGISTRY_USER and RH_REGISTRY_TOKEN must be set"
+    exit 1
+fi
+
+DOCKER_CONF="$PWD/.docker"
+mkdir -p "$DOCKER_CONF"
+docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
+docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
+docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+docker --config="$DOCKER_CONF" push "${IMAGE}:latest"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021 Red Hat, Inc
+# Copyright 2022 Red Hat, Inc
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -exv
+
+
+# --------------------------------------------
+# Options that must be configured by app owner
+# --------------------------------------------
+APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
+COMPONENT_NAME="insights-content-template-renderer"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+IMAGE="quay.io/cloudservices/insights-content-template-renderer"
+COMPONENTS="insights-content-template-renderer"  # space-separated list of components to laod
+COMPONENTS_W_RESOURCES="insights-content-template-renderer"  # component to keep
+CACHE_FROM_LATEST_IMAGE="true"
+
+export IQE_PLUGINS="ccx"
+export IQE_MARKER_EXPRESSION="smoke" # ccx_data_pipeline_smoke does not exits (at least yet) as marker in the plugin
+export IQE_FILTER_EXPRESSION=""
+export IQE_REQUIREMENTS_PRIORITY=""
+export IQE_TEST_IMPORTANCE=""
+export IQE_CJI_TIMEOUT="30m"
+
+
+function build_image() {
+    source $CICD_ROOT/build.sh
+}
+
+function deploy_ephemeral() {
+    source $CICD_ROOT/deploy_ephemeral_env.sh
+}
+
+function run_smoke_tests() {
+    # component name needs to be re-export to match ClowdApp name (as bonfire requires for this)
+    
+    # TODO: Uncomment when there are any tests
+    # export COMPONENT_NAME="insights-content-template-renderer"
+    # source $CICD_ROOT/cji_smoke_test.sh
+    echo "To be implemented"
+}
+
+
+# Install bonfire repo/initialize
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
+echo "creating PR image"
+build_image
+
+echo "deploying to ephemeral"
+deploy_ephemeral
+
+echo "running PR smoke tests"
+run_smoke_tests


### PR DESCRIPTION
Add `pr_check.sh` and `build_deploy.sh` to start building the quay image.

The CI/CD automation has been added at https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/47688.