### PR TITLE
Render content without affecting original format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,4 +29,4 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          pytest
+          pytest -vv

--- a/insights_content_template_renderer/DoT.py
+++ b/insights_content_template_renderer/DoT.py
@@ -27,7 +27,6 @@ Source: https://github.com/lucemia/doT
 
 import re
 
-
 version = '1.0.0'
 template_settings = {
     "evaluate": r"\{\{([\s\S]+?\}?)\}\}",
@@ -41,11 +40,10 @@ template_settings = {
     "conditional": r"\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}",
     "iterate": r"\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})",
     "varname": "it",
-    "strip": True,
+    "strip": False,
     "append": True,
     "selfcontained": False
 }
-
 
 startend = {
     "append": {
@@ -117,7 +115,7 @@ def template(tmpl, c=None, _def=None):
     def _evalute(code):
         return "';" + unescape(code) + "out+='"
 
-    _str = resolve_defs(c, tmpl, _def or {}) if(c["use"] or c["define"]) else tmpl
+    _str = resolve_defs(c, tmpl, _def or {}) if (c["use"] or c["define"]) else tmpl
 
     if c.get('strip'):
         # remove white space

--- a/insights_content_template_renderer/tests/DoT_test.py
+++ b/insights_content_template_renderer/tests/DoT_test.py
@@ -18,3 +18,13 @@ def test_single_quote_correct_handling():
         text
         == "An OCP node behaves unexpectedly when it doesn't meet the minimum resource requirements"
     )
+
+
+def test_newline_correct_handling():
+    """
+    Checks that DoT template function escapes single quotes
+    before creating a JS function out of them.
+    """
+    template = "This is a line\nAnd this is another line"
+    text = js2py.eval_js(DoT.template(template, DoT_settings))()
+    assert text == "This is a line\nAnd this is another line"

--- a/insights_content_template_renderer/tests/DoT_test.py
+++ b/insights_content_template_renderer/tests/DoT_test.py
@@ -20,11 +20,17 @@ def test_single_quote_correct_handling():
     )
 
 
-def test_newline_correct_handling():
+def test_nonletter_characters_correct_handling():
     """
-    Checks that DoT template function escapes single quotes
-    before creating a JS function out of them.
+    Checks that DoT.template function does not remove characters like
+    escape characers and single quotes from the given input if strip is
+    set to False
     """
-    template = "This is a line\nAnd this is another line"
-    text = js2py.eval_js(DoT.template(template, DoT_settings))()
-    assert text == "This is a line\nAnd this is another line"
+    input = r"Red Hat recommends that you configure your nodes to meet the minimum resource requirements.\n\nMake " \
+            r"sure that:\n\n1. Node foo1 (undefined) * Has enough memory, minimum requirement is 16. Currently its " \
+            r"only configured with 8.16GB. "
+
+    DoT_settings['strip'] = False
+
+    text = js2py.eval_js(DoT.template(input, DoT_settings))()
+    assert text == input

--- a/insights_content_template_renderer/tests/utils_test.py
+++ b/insights_content_template_renderer/tests/utils_test.py
@@ -76,8 +76,8 @@ def test_render_resolution():
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2].copy()
     result = (
-        "Red Hat recommends that you configure your nodes to meet the minimum resource "
-        "requirements.Make sure that:1. Node foo1 (undefined) * Has enough memory, "
+        "Red Hat recommends that you configure your nodes to meet the minimum resource " +
+        "requirements.\n\nMake sure that:\n\n1. Node foo1 (undefined) * Has enough memory, " +
         "minimum requirement is 16. Currently its only configured with 8.16GB."
     )
     assert utils.render_resolution(rule_content, report) == result

--- a/insights_content_template_renderer/tests/utils_test.py
+++ b/insights_content_template_renderer/tests/utils_test.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 from insights_content_template_renderer import utils
 
-
 test_data = {}
 test_data_path = Path(__file__).with_name("request_data_example.json")
 with test_data_path.open(encoding="UTF-8") as f:
@@ -66,9 +65,20 @@ def test_get_reported_error_key_key_field_missing():
         utils.get_reported_error_key(report)
 
 
+def test_escape_raw_text_for_JS():
+    """
+        Checks that the escape_raw_text_for_JS() function converts the input string
+        into its literal representation so it can be used properly by js2py.eval_js
+    """
+    text = "Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t   * Has enough memory,\n\t   * Has " \
+           "enough CPU. "
+    assert utils.escape_raw_text_for_JS(text) == r"Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t " \
+                                                 r"  * Has enough memory,\n\t   * Has enough CPU. "
+
+
 def test_render_resolution():
     """
-    Checks that th render_resolution() function renders resolution correctly.
+    Checks that the render_resolution() function renders resolution correctly.
     """
     cluster_reports = test_data["report_data"]["reports"][
         "5d5892d3-1f74-4ccf-91af-548dfc9767aa"
@@ -76,11 +86,12 @@ def test_render_resolution():
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2].copy()
     result = (
-        "Red Hat recommends that you configure your nodes to meet the minimum resource " +
-        "requirements.\n\nMake sure that:\n\n1. Node foo1 (undefined) * Has enough memory, " +
-        "minimum requirement is 16. Currently its only configured with 8.16GB."
+            r"Red Hat recommends that you configure your nodes to meet the minimum resource " +
+            r"requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough memory, " +
+            r"minimum requirement is 16. Currently its only configured with 8.16GB.\n"
     )
-    assert utils.render_resolution(rule_content, report) == result
+    rendered = utils.render_resolution(rule_content, report)
+    assert rendered == result
 
 
 def test_render_reason():
@@ -92,12 +103,13 @@ def test_render_reason():
     ]
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2]
-    assert (
-        utils.render_reason(rule_content, report) == "Node not meeting the minimum "
-        "requirements:1. foo1 * Roles: undefined "
-        "* Minimum memory requirement is 16, "
-        "but the node is configured with 8.16."
+    rendered = utils.render_reason(rule_content, report)
+    result = (
+        r"Node not meeting the minimum "
+        r"requirements:\n\n1. foo1\n  * Roles: undefined\n  * "
+        r"Minimum memory requirement is 16, but the node is configured with 8.16.\n"
     )
+    assert rendered == result
 
 
 def test_render_description():
@@ -110,8 +122,8 @@ def test_render_description():
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2]
     assert (
-        utils.render_description(rule_content, report)
-        == "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements"
+            utils.render_description(rule_content, report)
+            == "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements"
     )
 
 
@@ -127,15 +139,15 @@ def test_render_report():
     result = {
         "rule_id": "ccx_rules_ocp.external.rules.nodes_requirements_check",
         "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
-        "resolution": "Red Hat recommends that you configure your nodes to meet the minimum "
-        "resource requirements.Make sure that:1. Node foo1 (undefined) * Has enough "
-        "memory, minimum requirement is 16. Currently its only configured with "
-        "8.16GB.",
-        "reason": "Node not meeting the minimum requirements:1. foo1 * Roles: undefined * Minimum "
-        "memory requirement is 16, but the node is configured with 8.16.",
-        "description": "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements",
+        "resolution": r"Red Hat recommends that you configure your nodes to meet the minimum "
+                      r"resource requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough "
+                      r"memory, minimum requirement is 16. Currently its only configured with 8.16GB.\n",
+        "reason": r"Node not meeting the minimum requirements:\n\n1. foo1\n  * Roles: undefined\n  * Minimum "
+                  r"memory requirement is 16, but the node is configured with 8.16.\n",
+        "description": r"An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements",
     }
-    assert utils.render_report(content, report) == result
+    rendered = utils.render_report(content, report)
+    assert rendered == result
 
 
 def test_render_report_missing_rule_content():
@@ -158,55 +170,56 @@ def test_render_reports():
     Checks that render_reports() function renders all reports correctly.
     """
     result = {
-        "clusters": ["5d5892d3-1f74-4ccf-91af-548dfc9767aa"],
-        "reports": {
-            "5d5892d3-1f74-4ccf-91af-548dfc9767aa": [
+        'clusters': ['5d5892d3-1f74-4ccf-91af-548dfc9767aa'],
+        'reports': {
+            '5d5892d3-1f74-4ccf-91af-548dfc9767aa': [
                 {
-                    "rule_id": "ccx_rules_ocp.external.rules.nodes_requirements_check",
-                    "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
-                    "description": "An OCP node foo1 behaves unexpectedly when it doesn't meet "
-                    "the minimum resource requirements",
-                    "resolution": "Red Hat recommends that you configure your nodes to meet the "
-                    "minimum resource requirements.Make sure that:1. Node foo1 ("
-                    "undefined) * Has enough memory, minimum requirement is 16. "
-                    "Currently its only configured with 8.16GB.",
-                    "reason": "Node not meeting the minimum requirements:1. foo1 * Roles: "
-                    "undefined * Minimum memory requirement is 16, but the node is "
-                    "configured with 8.16.",
+                    'rule_id': 'ccx_rules_ocp.external.rules.nodes_requirements_check',
+                    'error_key': 'NODES_MINIMUM_REQUIREMENTS_NOT_MET',
+                    'resolution': 'Red Hat recommends that you configure your nodes to meet the minimum resource '
+                                  'requirements.\\n\\nMake sure that:\\n\\n\\n1. Node foo1 (undefined)\\n   * Has '
+                                  'enough memory, minimum requirement is 16. Currently its only configured with '
+                                  '8.16GB.\\n', 'reason': 'Node not meeting the minimum requirements:\\n\\n1. foo1\\n '
+                                                          ' * Roles: undefined\\n  * Minimum memory requirement is '
+                                                          '16, but the node is configured with 8.16.\\n',
+                    'description': "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource "
+                                   "requirements"
                 },
                 {
-                    "rule_id": "ccx_rules_ocp.external.rules.samples_op_failed_image_import_check",
-                    "error_key": "SAMPLES_FAILED_IMAGE_IMPORT_ERR",
-                    "description": "Pods could fail to start if openshift-samples is degraded "
-                    "due to FailedImageImport which is caused by a hiccup while "
-                    "talking to the Red Hat registry",
-                    "resolution": "Red Hat recommends that you to follow these steps:1. Fix 1, "
-                    "Try running:~~~# oc import-image <for the ImageStream(s) in "
-                    "question>~~~1. Fix 2, Try running:~~~# oc delete "
-                    "configs.samples cluster~~~",
-                    "reason": "Due to a temporary hiccup talking to the Red Hat registry the "
-                    "openshift-samples failed to import some of the imagestreams.Source "
-                    "of the issue:**Cluster-operator:**  **openshift-samples**- "
-                    "*Condition:* Degraded- *Reason:* FailedImageImports- *Message:* "
-                    "Samples installed at 4.2.0, with image import failures for these "
-                    "imagestreams: php - *Last* Transition: 2020-03-19T08:32:53Z",
+                    'rule_id': 'ccx_rules_ocp.external.rules.samples_op_failed_image_import_check',
+                    'error_key': 'SAMPLES_FAILED_IMAGE_IMPORT_ERR',
+                    'resolution': 'Red Hat recommends that you to follow these steps:\\n\\n1. Fix 1, '
+                                  'Try running:\\n~~~\\n# oc import-image <for the ImageStream(s) in '
+                                  'question>\\n~~~\\n\\n1. Fix 2, Try running:\\n~~~\\n# oc delete configs.samples '
+                                  'cluster\\n~~~',
+                    'reason': 'Due to a temporary hiccup talking to the Red Hat '
+                              'registry the openshift-samples failed to import some of '
+                              'the imagestreams.\\n\\n\\nSource of the '
+                              'issue:\\n\\n**Cluster-operator:**  '
+                              '**openshift-samples**\\n- *Condition:* Degraded\\n- '
+                              '*Reason:* FailedImageImports\\n- *Message:* Samples '
+                              'installed at 4.2.0, with image import failures for '
+                              'these imagestreams: php \\n- *Last* Transition: '
+                              '2020-03-19T08:32:53Z\\n',
+                    'description': 'Pods could fail to start if openshift-samples is degraded due to '
+                                   'FailedImageImport which is caused by a hiccup while talking to the Red Hat registry'
                 },
                 {
-                    "rule_id": "ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check",
-                    "error_key": "AUTH_OPERATOR_PROXY_ERROR",
-                    "description": "The authentication operator is degraded when cluster "
-                    "is configured to use a cluster-wide proxy",
-                    "resolution": "Red Hat recommends that you to follow steps in the KCS "
-                    "article. * [Authentication operator Degraded with Reason "
-                    "`WellKnownEndpointDegradedError`]("
-                    "https://access.redhat.com/solutions/4569191)",
-                    "reason": "Requests to routes and/or the public API endpoint are not being "
-                    "proxied to the cluster.",
-                },
+                    'rule_id': 'ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check',
+                    'error_key': 'AUTH_OPERATOR_PROXY_ERROR',
+                    'resolution': 'Red Hat recommends that you to follow steps in the KCS article.\\n * ['
+                                  'Authentication operator Degraded with Reason `WellKnownEndpointDegradedError`]('
+                                  'https://access.redhat.com/solutions/4569191)\\n',
+                    'reason': 'Requests to routes and/or the public API endpoint are not being proxied to the '
+                              'cluster.\\n',
+                    'description': 'The authentication operator is degraded when cluster is configured to use a '
+                                   'cluster-wide proxy'
+                }
             ]
-        },
+        }
     }
-    assert utils.render_reports(test_data) == result
+    rendered = utils.render_reports(test_data)
+    assert rendered == result
 
 
 def test_render_reports_missing_content():

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -49,6 +49,14 @@ def get_reported_error_key(report):
     return report["key"]
 
 
+def escape_raw_text_for_JS(text):
+    """
+    Escapes all the escape characters like whitespace, newline, tabulation,
+    etc, as well as single quotes.
+    """
+    return text.encode("unicode_escape").decode()
+
+
 def get_template_function(template_name, template_text, report):
     """
     Retrieves the DoT.js template based on the name of the field in the given content data
@@ -66,7 +74,10 @@ def get_template_function(template_name, template_text, report):
             f"Template '{template_name}' has not been found for rule '{reported_module}' "
             + f"and error key '{reported_error_key}'."
         )
-    return js2py.eval_js(DoT.template(template_text, DoT_settings))
+    log.info(template_text)
+    template = DoT.template(escape_raw_text_for_JS(template_text), DoT_settings)
+    log.info(template)
+    return js2py.eval_js(template)
 
 
 def render_description(rule_content, report):


### PR DESCRIPTION
Make the template-renderer keep the original format of the content's resolution, reason and description fields by escaping it before passing it to the JS-related libraries.