### PR TITLE
Undo escaping for Javascript after template is evaluated

### DIFF
--- a/insights_content_template_renderer/tests/utils_test.py
+++ b/insights_content_template_renderer/tests/utils_test.py
@@ -65,14 +65,14 @@ def test_get_reported_error_key_key_field_missing():
         utils.get_reported_error_key(report)
 
 
-def test_escape_raw_text_for_JS():
+def test_escape_raw_text_for_js():
     """
         Checks that the escape_raw_text_for_JS() function converts the input string
         into its literal representation so it can be used properly by js2py.eval_js
     """
     text = "Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t   * Has enough memory,\n\t   * Has " \
            "enough CPU. "
-    assert utils.escape_raw_text_for_JS(text) == r"Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t " \
+    assert utils.escape_raw_text_for_js(text) == r"Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t " \
                                                  r"  * Has enough memory,\n\t   * Has enough CPU. "
 
 
@@ -85,11 +85,10 @@ def test_render_resolution():
     ]
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2].copy()
-    result = (
-            r"Red Hat recommends that you configure your nodes to meet the minimum resource " +
-            r"requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough memory, " +
-            r"minimum requirement is 16. Currently its only configured with 8.16GB.\n"
-    )
+    result = "Red Hat recommends that you configure your nodes to meet the minimum resource requirements.\n\nMake " \
+             "sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough memory, minimum requirement is 16. Currently " \
+             "its only configured with 8.16GB.\n"
+
     rendered = utils.render_resolution(rule_content, report)
     assert rendered == result
 
@@ -104,11 +103,9 @@ def test_render_reason():
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2]
     rendered = utils.render_reason(rule_content, report)
-    result = (
-        r"Node not meeting the minimum "
-        r"requirements:\n\n1. foo1\n  * Roles: undefined\n  * "
-        r"Minimum memory requirement is 16, but the node is configured with 8.16.\n"
-    )
+    result = "Node not meeting the minimum " \
+             "requirements:\n\n1. foo1\n  * Roles: undefined\n  * " \
+             "Minimum memory requirement is 16, but the node is configured with 8.16.\n"
     assert rendered == result
 
 
@@ -121,10 +118,11 @@ def test_render_description():
     ]
     report = cluster_reports["reports"][0].copy()
     rule_content = test_data["content"][2]
-    assert (
-            utils.render_description(rule_content, report)
-            == "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements"
-    )
+    result = "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements"
+    rendered = utils.render_description(rule_content, report)
+
+    assert rendered == result
+
 
 
 def test_render_report():
@@ -139,12 +137,12 @@ def test_render_report():
     result = {
         "rule_id": "ccx_rules_ocp.external.rules.nodes_requirements_check",
         "error_key": "NODES_MINIMUM_REQUIREMENTS_NOT_MET",
-        "resolution": r"Red Hat recommends that you configure your nodes to meet the minimum "
-                      r"resource requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough "
-                      r"memory, minimum requirement is 16. Currently its only configured with 8.16GB.\n",
-        "reason": r"Node not meeting the minimum requirements:\n\n1. foo1\n  * Roles: undefined\n  * Minimum "
-                  r"memory requirement is 16, but the node is configured with 8.16.\n",
-        "description": r"An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements",
+        "resolution": "Red Hat recommends that you configure your nodes to meet the minimum "\
+                      "resource requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough "\
+                      "memory, minimum requirement is 16. Currently its only configured with 8.16GB.\n",
+        "reason": "Node not meeting the minimum requirements:\n\n1. foo1\n  * Roles: undefined\n  * Minimum "\
+                  "memory requirement is 16, but the node is configured with 8.16.\n",
+        "description": "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements",
     }
     rendered = utils.render_report(content, report)
     assert rendered == result
@@ -170,50 +168,31 @@ def test_render_reports():
     Checks that render_reports() function renders all reports correctly.
     """
     result = {
-        'clusters': ['5d5892d3-1f74-4ccf-91af-548dfc9767aa'],
+        'clusters': [
+            '5d5892d3-1f74-4ccf-91af-548dfc9767aa'
+        ],
         'reports': {
             '5d5892d3-1f74-4ccf-91af-548dfc9767aa': [
                 {
                     'rule_id': 'ccx_rules_ocp.external.rules.nodes_requirements_check',
                     'error_key': 'NODES_MINIMUM_REQUIREMENTS_NOT_MET',
-                    'resolution': 'Red Hat recommends that you configure your nodes to meet the minimum resource '
-                                  'requirements.\\n\\nMake sure that:\\n\\n\\n1. Node foo1 (undefined)\\n   * Has '
-                                  'enough memory, minimum requirement is 16. Currently its only configured with '
-                                  '8.16GB.\\n', 'reason': 'Node not meeting the minimum requirements:\\n\\n1. foo1\\n '
-                                                          ' * Roles: undefined\\n  * Minimum memory requirement is '
-                                                          '16, but the node is configured with 8.16.\\n',
-                    'description': "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource "
-                                   "requirements"
+                    'resolution': "Red Hat recommends that you configure your nodes to meet the minimum resource requirements.\n\nMake sure that:\n\n\n1. Node foo1 (undefined)\n   * Has enough memory, minimum requirement is 16. Currently its only configured with 8.16GB.\n",
+                    'reason': "Node not meeting the minimum requirements:\n\n1. foo1\n  * Roles: undefined\n  * Minimum memory requirement is 16, but the node is configured with 8.16.\n",
+                    'description': "An OCP node foo1 behaves unexpectedly when it doesn't meet the minimum resource requirements"
                 },
                 {
                     'rule_id': 'ccx_rules_ocp.external.rules.samples_op_failed_image_import_check',
                     'error_key': 'SAMPLES_FAILED_IMAGE_IMPORT_ERR',
-                    'resolution': 'Red Hat recommends that you to follow these steps:\\n\\n1. Fix 1, '
-                                  'Try running:\\n~~~\\n# oc import-image <for the ImageStream(s) in '
-                                  'question>\\n~~~\\n\\n1. Fix 2, Try running:\\n~~~\\n# oc delete configs.samples '
-                                  'cluster\\n~~~',
-                    'reason': 'Due to a temporary hiccup talking to the Red Hat '
-                              'registry the openshift-samples failed to import some of '
-                              'the imagestreams.\\n\\n\\nSource of the '
-                              'issue:\\n\\n**Cluster-operator:**  '
-                              '**openshift-samples**\\n- *Condition:* Degraded\\n- '
-                              '*Reason:* FailedImageImports\\n- *Message:* Samples '
-                              'installed at 4.2.0, with image import failures for '
-                              'these imagestreams: php \\n- *Last* Transition: '
-                              '2020-03-19T08:32:53Z\\n',
-                    'description': 'Pods could fail to start if openshift-samples is degraded due to '
-                                   'FailedImageImport which is caused by a hiccup while talking to the Red Hat registry'
+                    'resolution': "Red Hat recommends that you to follow these steps:\n\n1. Fix 1, Try running:\n~~~\n# oc import-image <for the ImageStream(s) in question>\n~~~\n\n1. Fix 2, Try running:\n~~~\n# oc delete configs.samples cluster\n~~~",
+                    'reason': "Due to a temporary hiccup talking to the Red Hat registry the openshift-samples failed to import some of the imagestreams.\n\n\nSource of the issue:\n\n**Cluster-operator:**  **openshift-samples**\n- *Condition:* Degraded\n- *Reason:* FailedImageImports\n- *Message:* Samples installed at 4.2.0, with image import failures for these imagestreams: php \n- *Last* Transition: 2020-03-19T08:32:53Z\n",
+                    'description': "Pods could fail to start if openshift-samples is degraded due to FailedImageImport which is caused by a hiccup while talking to the Red Hat registry"
                 },
                 {
                     'rule_id': 'ccx_rules_ocp.external.rules.cluster_wide_proxy_auth_check',
                     'error_key': 'AUTH_OPERATOR_PROXY_ERROR',
-                    'resolution': 'Red Hat recommends that you to follow steps in the KCS article.\\n * ['
-                                  'Authentication operator Degraded with Reason `WellKnownEndpointDegradedError`]('
-                                  'https://access.redhat.com/solutions/4569191)\\n',
-                    'reason': 'Requests to routes and/or the public API endpoint are not being proxied to the '
-                              'cluster.\\n',
-                    'description': 'The authentication operator is degraded when cluster is configured to use a '
-                                   'cluster-wide proxy'
+                    'resolution': "Red Hat recommends that you to follow steps in the KCS article.\n * [Authentication operator Degraded with Reason `WellKnownEndpointDegradedError`](https://access.redhat.com/solutions/4569191)\n",
+                    'reason': "Requests to routes and/or the public API endpoint are not being proxied to the cluster.\n",
+                    'description': "The authentication operator is degraded when cluster is configured to use a cluster-wide proxy"
                 }
             ]
         }

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -49,12 +49,20 @@ def get_reported_error_key(report):
     return report["key"]
 
 
-def escape_raw_text_for_JS(text):
+def escape_raw_text_for_js(text):
     """
     Escapes all the escape characters like whitespace, newline, tabulation,
     etc, as well as single quotes.
     """
     return text.encode("unicode_escape").decode()
+
+
+def unescape_raw_text_for_python(text):
+    """
+    Undoes all the escaping of special characters like whitespace, newline, tabulation,
+    etc, as well as single quotes.
+    """
+    return text.encode().decode('unicode-escape')
 
 
 def get_template_function(template_name, template_text, report):
@@ -75,8 +83,7 @@ def get_template_function(template_name, template_text, report):
             + f"and error key '{reported_error_key}'."
         )
     log.info(template_text)
-    template = DoT.template(escape_raw_text_for_JS(template_text), DoT_settings)
-    log.info(template)
+    template = DoT.template(escape_raw_text_for_js(template_text), DoT_settings)
     return js2py.eval_js(template)
 
 
@@ -103,7 +110,7 @@ def render_description(rule_content, report):
         )
     except TemplateNotFoundException:
         return ""
-    return description_template(report["details"])
+    return unescape_raw_text_for_python(description_template(report["details"]))
 
 
 def render_resolution(rule_content, report):
@@ -126,7 +133,7 @@ def render_resolution(rule_content, report):
         resolution_template = get_template_function("resolution", template_text, report)
     except TemplateNotFoundException:
         return ""
-    return resolution_template(report["details"])
+    return unescape_raw_text_for_python(resolution_template(report["details"]))
 
 
 def render_reason(rule_content, report):
@@ -149,7 +156,7 @@ def render_reason(rule_content, report):
         reason_template = get_template_function("reason", template_text, report)
     except TemplateNotFoundException:
         return ""
-    return reason_template(report["details"])
+    return unescape_raw_text_for_python(reason_template(report["details"]))
 
 
 def render_report(content, report):


### PR DESCRIPTION
We cannot undo the special characters escaping until after `js2py.eval_js` is finished.
This PR fix the formatting issue, but this needs some BDD and some refactoring.