### PR TITLE
[CCXDEV-10314] Print JS template if it cannot be rendered

### DIFF
--- a/insights_content_template_renderer/endpoints.py
+++ b/insights_content_template_renderer/endpoints.py
@@ -31,7 +31,6 @@ async def rendered_reports(data: RendererRequest):
     :return: JSON with rendered reports
     """
     log.info("Received request for /rendered_reports")
-    # print(data)
     log.debug("Rendering report")
     rendered_report = render_reports(data)
     log.debug("Report successfully rendered")

--- a/insights_content_template_renderer/tests/test_endpoints.py
+++ b/insights_content_template_renderer/tests/test_endpoints.py
@@ -24,6 +24,5 @@ def test_no_data():
 def test_valid_data():
     response = client.post(ENDPOINT__V1_RENDERED_REPORTS, json=example_request_data)
     assert response.status_code == status.HTTP_200_OK
-    print(response.json())
     assert response.json() == example_response_data
 

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -87,7 +87,11 @@ def get_template_function(template_name, template_text, report: Report):
     log.debug(template_text)
 
     template = renderer.template(escape_raw_text_for_js(template_text), DoT_settings)
-    return js2py.eval_js(template)
+    try:
+        return js2py.eval_js(template)
+    except Exception as ex:
+        log.error(f"cannot evaluate JS template:\n{template}")
+        raise Exception('Cannot evaluate JS code') from ex
 
 
 def render_description(rule_content: Content, report: Report):

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -90,7 +90,9 @@ def get_template_function(template_name, template_text, report: Report):
     try:
         return js2py.eval_js(template)
     except Exception as ex:
-        log.error(f"cannot evaluate JS template:\n{template}")
+        log.error(f"cannot evaluate JS template")
+        log.error(f"template: {template}")
+        log.error(f"report: {report}")
         raise Exception('Cannot evaluate JS code') from ex
 
 

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -89,7 +89,7 @@ def get_template_function(template_name, template_text, report: Report):
     template = renderer.template(escape_raw_text_for_js(template_text), DoT_settings)
     try:
         return js2py.eval_js(template)
-    except Exception as ex:
+    except js2py.internals.simplex.JsException as ex:
         log.error(f"cannot evaluate JS template")
         log.error(f"template: {template}")
         log.error(f"report: {report}")


### PR DESCRIPTION
It seems like the errors we have in production are related to some report not being rendered due to some JS syntax error. Let's print the template and the report so that we can get a sample and then try to debug locally.

The error in prod:

```
timestamp=2023-03-27 15:06:32,553 pid=7 loglevel=INFO msg=Received request for /rendered_reports
timestamp=2023-03-27 15:06:32,553 pid=7 loglevel=INFO msg=Loading content and report data
timestamp=2023-03-27 15:06:32,553 pid=7 loglevel=INFO msg=Iterating through the reports of each cluster
Exception in ASGI application
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 429, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/opt/app-root/lib64/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 86, in __call__
    raise exc from None
  File "/opt/app-root/lib64/python3.9/site-packages/uvicorn/middleware/message_logger.py", line 82, in __call__
    await self.app(scope, inner_receive, inner_send)
  File "/opt/app-root/lib64/python3.9/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/opt/app-root/lib64/python3.9/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 169, in __call__
    raise exc
  File "/opt/app-root/lib64/python3.9/site-packages/prometheus_fastapi_instrumentator/middleware.py", line 167, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/opt/app-root/lib64/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/opt/app-root/lib64/python3.9/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/opt/app-root/lib64/python3.9/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/opt/app-root/lib64/python3.9/site-packages/fastapi/routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "/opt/app-root/lib64/python3.9/site-packages/fastapi/routing.py", line 163, in run_endpoint_function
    return await dependant.call(**values)
  File "/opt/app-root/lib64/python3.9/site-packages/insights_content_template_renderer/endpoints.py", line 36, in rendered_reports
    rendered_report = render_reports(data)
  File "/opt/app-root/lib64/python3.9/site-packages/insights_content_template_renderer/utils.py", line 215, in render_reports
    report_result = render_report(content, report)
  File "/opt/app-root/lib64/python3.9/site-packages/insights_content_template_renderer/utils.py", line 185, in render_report
    reason = render_reason(rule, report),
  File "/opt/app-root/lib64/python3.9/site-packages/insights_content_template_renderer/utils.py", line 159, in render_reason
    reason_template = get_template_function("reason", template_text, report)
  File "/opt/app-root/lib64/python3.9/site-packages/insights_content_template_renderer/utils.py", line 90, in get_template_function
    return js2py.eval_js(template)
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/evaljs.py", line 115, in eval_js
    return e.eval(js)
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/evaljs.py", line 204, in eval
    self.execute(code, use_compilation_plan=use_compilation_plan)
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/evaljs.py", line 199, in execute
    exec (compiled, self._context)
  File "<EvalJS snippet>", line 4, in <module>
  File "<EvalJS snippet>", line 3, in PyJs_LONG_0_
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/base.py", line 949, in __call__
    return self.call(self.GlobalObject, args)
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/base.py", line 1464, in call
    return Js(self.code(*args))
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/host/jseval.py", line 17, in Eval
    py_code = translate_js(code.to_string().value, '')
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/translators/translator.py", line 70, in translate_js
    parsed = parse_fn(js)
  File "/opt/app-root/lib64/python3.9/site-packages/js2py/translators/translator.py", line 62, in pyjsparser_parse_fn
    return parser.parse(code)
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 3008, in parse
    program = self.parseProgram()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2974, in parseProgram
    body = self.parseScriptBody()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2963, in parseScriptBody
    statement = self.parseStatementListItem()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2105, in parseStatementListItem
    return self.parseFunctionDeclaration(Node())
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2878, in parseFunctionDeclaration
    body = self.parseFunctionSourceElements()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2765, in parseFunctionSourceElements
    body.append(self.parseStatementListItem())
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2110, in parseStatementListItem
    return self.parseStatement()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2689, in parseStatement
    return self.parseIfStatement(node)
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2273, in parseIfStatement
    test = self.parseExpression()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2076, in parseExpression
    expr = self.isolateCoverGrammar(self.parseAssignmentExpression)
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 1161, in isolateCoverGrammar
    result = parser()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 2038, in parseAssignmentExpression
    expr = self.parseConditionalExpression()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 1931, in parseConditionalExpression
    expr = self.inheritCoverGrammar(self.parseBinaryExpression)
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 1176, in inheritCoverGrammar
    result = parser()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 1884, in parseBinaryExpression
    self.lex()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 972, in lex
    self.lookahead = self.advance()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 917, in advance
    return self.scanNumericLiteral()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 505, in scanNumericLiteral
    self.throwUnexpectedToken()
  File "/opt/app-root/lib64/python3.9/site-packages/pyjsparser/parser.py", line 1046, in throwUnexpectedToken
    raise self.unexpectedTokenError(token, message)
js2py.internals.simplex.JsException: SyntaxError: Line 1: Unexpected token ILLEGAL

```