### PR TITLE
[CCXDEV-10294] Print the request body if there is any error

### DIFF
--- a/insights_content_template_renderer/endpoints.py
+++ b/insights_content_template_renderer/endpoints.py
@@ -4,6 +4,7 @@ Contains service endpoints.
 
 import logging
 from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from insights_content_template_renderer.utils import render_reports
@@ -32,6 +33,12 @@ async def rendered_reports(data: RendererRequest):
     """
     log.info("Received request for /rendered_reports")
     log.debug("Rendering report")
-    rendered_report = render_reports(data)
-    log.debug("Report successfully rendered")
+    try:
+        rendered_report = render_reports(data)
+        log.debug("Report successfully rendered")
+    except Exception as exc:
+        log.error("error rendering template")
+        log.error(f"data:\n{data.json()}")
+        log.error(f"exception:\n{exc}")
+        return PlainTextResponse("Internal Server Error", 500)
     return rendered_report

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -87,13 +87,7 @@ def get_template_function(template_name, template_text, report: Report):
     log.debug(template_text)
 
     template = renderer.template(escape_raw_text_for_js(template_text), DoT_settings)
-    try:
-        return js2py.eval_js(template)
-    except js2py.internals.simplex.JsException as ex:
-        log.error(f"cannot evaluate JS template")
-        log.error(f"template: {template}")
-        log.error(f"report: {report}")
-        raise Exception('Cannot evaluate JS code') from ex
+    return js2py.eval_js(template)
 
 
 def render_description(rule_content: Content, report: Report):


### PR DESCRIPTION
With the changes in https://github.com/RedHatInsights/insights-content-template-renderer/pull/27 I found that there is just one report failing:

```
❯ oc logs {RENDERER_POD}| grep "ccx_rules_ocp" | awk '{ print $7 }' | uniq
component='ccx_rules_ocp.external.rules.openshift_sdn_egress_ip_in_no_hostsubnet.report'
```

In order to reproduce and understand the issue, I need to log the full request as with the previous changes we were logging just the report.