### PR TITLE
[CCXDEV-10294] Escape newlines inside curly brackets

### DIFF
--- a/insights_content_template_renderer/tests/utils_test.py
+++ b/insights_content_template_renderer/tests/utils_test.py
@@ -151,3 +151,20 @@ def test_render_reports():
     rendered = utils.render_reports(req)
     assert RendererResponse.parse_obj(rendered) == result
 
+
+def test_escape_new_line_inside_brackets():
+    input = "Text\nwith a {{newline\n}} inside the brackets"
+    input = """
+{{?pydata.test.length>1
+}}First if{{?? pydata.test[0]['subtest'].length>1
+}}Second if{{??
+}}Third if{{?}}.
+
+More text
+"""
+    output = utils.escape_new_line_inside_brackets(input)
+    assert output == """
+{{?pydata.test.length>1}}First if{{?? pydata.test[0]['subtest'].length>1}}Second if{{??}}Third if{{?}}.
+
+More text
+"""

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -5,6 +5,7 @@ Provides all business logic for this service.
 import logging
 import js2py
 from typing import List
+import re
 
 from insights_content_template_renderer import DoT
 from insights_content_template_renderer.DoT import DEFAULT_TEMPLATE_SETTINGS
@@ -50,13 +51,22 @@ def get_reported_error_key(report: Report) -> str:
     """
     return report.key
 
+def escape_new_line_inside_brackets(text):
+    """
+    Escape the new lines inside brackets that were causing some issues.
+
+    https://issues.redhat.com/browse/CCXDEV-10314
+    """
+    return re.sub(r'\n(?=[^{{}}]*})', '', text)
+
 
 def escape_raw_text_for_js(text):
     """
     Escapes all the escape characters like whitespace, newline, tabulation,
     etc, as well as single quotes.
     """
-    return text.encode("unicode_escape").decode()
+    no_newlines = escape_new_line_inside_brackets(text)
+    return no_newlines.encode("unicode_escape").decode()
 
 
 def unescape_raw_text_for_python(text):


### PR DESCRIPTION
If the template contains some newline inside the curly brackets, the generated JS isn't valid. Let's fix that by removing newlines from curly brackets.