### PR TITLE
[CCXDEV-10294] Re-enable strip

### DIFF
--- a/insights_content_template_renderer/DoT.py
+++ b/insights_content_template_renderer/DoT.py
@@ -41,7 +41,7 @@ DEFAULT_TEMPLATE_SETTINGS = {
     "conditional": r"\{\{\?(\?)?\s*([\s\S]*?)\s*\}\}",
     "iterate": r"\{\{~\s*(?:\}\}|([\s\S]+?)\s*\:\s*([\w$]+)\s*(?:\:\s*([\w$]+))?\s*\}\})",
     "varname": "it",
-    "strip": False,
+    "strip": True,
     "append": True,
     "selfcontained": False,
 }

--- a/insights_content_template_renderer/tests/DoT_test.py
+++ b/insights_content_template_renderer/tests/DoT_test.py
@@ -31,7 +31,5 @@ def test_nonletter_characters_correct_handling():
             r"sure that:\n\n1. Node foo1 (undefined) * Has enough memory, minimum requirement is 16. Currently its " \
             r"only configured with 8.16GB. "
 
-    DoT_settings['strip'] = False
-
     text = js2py.eval_js(renderer.template(input, DoT_settings))()
     assert text == input

--- a/insights_content_template_renderer/tests/utils_test.py
+++ b/insights_content_template_renderer/tests/utils_test.py
@@ -35,17 +35,6 @@ def test_get_reported_module():
     assert reported_module == "ccx_rules_ocp.external.rules.1"
 
 
-def test_escape_raw_text_for_js():
-    """
-        Checks that the escape_raw_text_for_JS() function converts the input string
-        into its literal representation so it can be used properly by js2py.eval_js
-    """
-    text = "Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t   * Has enough memory,\n\t   * Has " \
-           "enough CPU. "
-    assert utils.escape_raw_text_for_js(text) == r"Something to report.\n\nMake sure that:\n\t1Node is alive and\n\t " \
-                                                 r"  * Has enough memory,\n\t   * Has enough CPU. "
-
-
 def test_render_resolution():
     """
     Checks that the render_resolution() function renders resolution correctly.
@@ -150,21 +139,3 @@ def test_render_reports():
     req = RendererRequest.parse_obj(example_request_data)
     rendered = utils.render_reports(req)
     assert RendererResponse.parse_obj(rendered) == result
-
-
-def test_escape_new_line_inside_brackets():
-    input = "Text\nwith a {{newline\n}} inside the brackets"
-    input = """
-{{?pydata.test.length>1
-}}First if{{?? pydata.test[0]['subtest'].length>1
-}}Second if{{??
-}}Third if{{?}}.
-
-More text
-"""
-    output = utils.escape_new_line_inside_brackets(input)
-    assert output == """
-{{?pydata.test.length>1}}First if{{?? pydata.test[0]['subtest'].length>1}}Second if{{??}}Third if{{?}}.
-
-More text
-"""

--- a/insights_content_template_renderer/utils.py
+++ b/insights_content_template_renderer/utils.py
@@ -51,23 +51,6 @@ def get_reported_error_key(report: Report) -> str:
     """
     return report.key
 
-def escape_new_line_inside_brackets(text):
-    """
-    Escape the new lines inside brackets that were causing some issues.
-
-    https://issues.redhat.com/browse/CCXDEV-10314
-    """
-    return re.sub(r'\n(?=[^{{}}]*})', '', text)
-
-
-def escape_raw_text_for_js(text):
-    """
-    Escapes all the escape characters like whitespace, newline, tabulation,
-    etc, as well as single quotes.
-    """
-    no_newlines = escape_new_line_inside_brackets(text)
-    return no_newlines.encode("unicode_escape").decode()
-
 
 def unescape_raw_text_for_python(text):
     """
@@ -96,7 +79,7 @@ def get_template_function(template_name, template_text, report: Report):
         )
     log.debug(template_text)
 
-    template = renderer.template(escape_raw_text_for_js(template_text), DoT_settings)
+    template = renderer.template(template_text, DoT_settings)
     return js2py.eval_js(template)
 
 


### PR DESCRIPTION
At some point (https://github.com/RedHatInsights/insights-content-template-renderer/commit/4a52823bc7b49e69b63eedb4268f4619d1a29aa7) we disabled the `strip` option in the configuration and added a function to manually escape characters. The upstream library is not using this + works fine with our buggy report, so let's get rid of it.

## Testing

Unit tests + the original report that is erroring