### PR TITLE
[CCXDEV-10434] Update base image to fix CVE-2023-25690 and CVE-2023-27522

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-39:1-97.1675807508
+FROM registry.access.redhat.com/ubi9/python-39:1-114
 
 WORKDIR /insights-content-template-renderer
 


### PR DESCRIPTION
#### Summary

Use latest ubi9/python3-9 that includes the security fixes for the mentioned CVEs

#### Type of change

- Bump-up dependent library (no changes in the code)

#### Testing steps

Built the image locally and tested it


Part of CCXDEV-10434