### PR TITLE
Remove unsupported Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
In the [2.0.0 release of dot-js](https://pypi.org/project/dot-js-py/), the support for `< Python3.8` was removed. Before this release, it was `> Python 2.7` . [This](https://github.com/lucemia/doT/compare/1.0.0...2.0.0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11) is the changed line.

As this service is built using a Python3.9 Docker image, removing `< Python3.8` versions in the `build` action doesn't matter.