### PR TITLE
[CCXDEV-10816] Use ubi8-minimal to remove not-needed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,36 @@
-FROM registry.access.redhat.com/ubi9/python-39:1-117
+FROM registry.access.redhat.com/ubi8-minimal:8.8-860
 
-WORKDIR /insights-content-template-renderer
+ENV VENV=/insights-content-template-renderer-venv \
+    HOME=/insights-content-template-renderer
+#    REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
-COPY . /insights-content-template-renderer
+RUN microdnf install python3.9
+WORKDIR $HOME
 
-USER 0
+COPY . $HOME
 
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
-RUN pip install --no-cache-dir --upgrade -r requirements.txt
+ENV PATH="$VENV/bin:$PATH" \
+    CONFIG_PATH="$HOME/config.yml"
+
+RUN microdnf install --nodocs -y python39-pip unzip
+RUN python -m venv $VENV
+#RUN curl -ksL https://password.corp.redhat.com/RH-IT-Root-CA.crt \
+#    -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
+#    update-ca-trust
+RUN pip install --verbose --no-cache-dir -U pip setuptools wheel
+RUN pip install --verbose --no-cache-dir -r requirements.txt
 RUN pip install .
+
+RUN microdnf remove -y unzip python39-pip
+RUN microdnf clean all
+RUN chmod -R g=u $HOME $VENV /etc/passwd && \
+    chgrp -R 0 $HOME $VENV
 
 USER 1001
 
 EXPOSE 8000
 
-CMD ["insights-content-template-renderer", "--config", "config.yml"]
+ENV PATH="$VENV/bin:$PATH" \
+    CONFIG_PATH="$HOME/config.yml"
+
+CMD ["sh", "-c", "insights-content-template-renderer --config $CONFIG_PATH"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@ FROM registry.access.redhat.com/ubi8-minimal:8.8-860
 
 ENV VENV=/insights-content-template-renderer-venv \
     HOME=/insights-content-template-renderer
-#    REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
-RUN microdnf install python3.9
+RUN microdnf install --nodocs --noplugins -y python3.11
 
 WORKDIR $HOME
 
@@ -13,23 +12,17 @@ COPY . $HOME
 ENV PATH="$VENV/bin:$PATH" \
     CONFIG_PATH="$HOME/config.yml"
 
-# RUN microdnf install --nodocs -y python39-pip unzip
 RUN python -m venv $VENV
-#RUN curl -ksL https://password.corp.redhat.com/RH-IT-Root-CA.crt \
-#    -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
-#    update-ca-trust
 RUN pip install --verbose --no-cache-dir -U pip setuptools wheel
 RUN pip install --verbose --no-cache-dir -r requirements.txt
 RUN pip install .
 
-# Clean up unnecessary packages for execution
-#RUN pip uninstall --verbose -y wheel setuptools pip
-#RUN microdnf remove -y unzip python39-pip
-RUN microdnf clean all
-#RUN chmod -R g=u $HOME $VENV /etc/passwd && \
-#    chgrp -R 0 $HOME $VENV
+# Clean up not necessary packages if useful
+RUN pip uninstall -y py #https://pypi.org/project/py/
 
-#USER 1001
+RUN microdnf clean all
+
+USER 1001
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV VENV=/insights-content-template-renderer-venv \
 #    REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
 RUN microdnf install python3.9
+
 WORKDIR $HOME
 
 COPY . $HOME
@@ -12,7 +13,7 @@ COPY . $HOME
 ENV PATH="$VENV/bin:$PATH" \
     CONFIG_PATH="$HOME/config.yml"
 
-RUN microdnf install --nodocs -y python39-pip unzip
+# RUN microdnf install --nodocs -y python39-pip unzip
 RUN python -m venv $VENV
 #RUN curl -ksL https://password.corp.redhat.com/RH-IT-Root-CA.crt \
 #    -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt && \
@@ -21,12 +22,14 @@ RUN pip install --verbose --no-cache-dir -U pip setuptools wheel
 RUN pip install --verbose --no-cache-dir -r requirements.txt
 RUN pip install .
 
-RUN microdnf remove -y unzip python39-pip
+# Clean up unnecessary packages for execution
+#RUN pip uninstall --verbose -y wheel setuptools pip
+#RUN microdnf remove -y unzip python39-pip
 RUN microdnf clean all
-RUN chmod -R g=u $HOME $VENV /etc/passwd && \
-    chgrp -R 0 $HOME $VENV
+#RUN chmod -R g=u $HOME $VENV /etc/passwd && \
+#    chgrp -R 0 $HOME $VENV
 
-USER 1001
+#USER 1001
 
 EXPOSE 8000
 


### PR DESCRIPTION
- Instead of just removing libtiff, this switches from ubi8-python39 to ubi8-minimal to avoid having unnecessary images in our Docker image.
- It now uses python3.11 instead of python3.9 (the available RPM for python3.9 bring many unnecessary dependencies and vulnerabilities)
- the `py` package is also removed, as it is not maintained anymore and has high security know vulnerabilities. It is part of the default python installation on this container, but is not needed by our service.