### PR TITLE
Using newer version of base image to fix CVE-2023-1667

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.8-860
+FROM registry.access.redhat.com/ubi8-minimal:8.8-1037
 
 ENV VENV=/insights-content-template-renderer-venv \
     HOME=/insights-content-template-renderer


### PR DESCRIPTION
Updating the base image to use newer version of some packages affected by the mentioned CVE.

#CCXDEV-10554