### PR TITLE
[CCXDEV-10828] Add sentry logging

### DIFF
--- a/insights_content_template_renderer/endpoints.py
+++ b/insights_content_template_renderer/endpoints.py
@@ -9,8 +9,10 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from insights_content_template_renderer.utils import render_reports
 from insights_content_template_renderer.models import RendererRequest, RendererResponse
+from insights_content_template_renderer.logging_sentry import init_sentry
 
 
+init_sentry()
 app = FastAPI()
 log = logging.getLogger(__name__)
 
@@ -33,6 +35,7 @@ async def rendered_reports(data: RendererRequest):
     """
     log.info("Received request for /rendered_reports")
     log.debug("Rendering report")
+
     try:
         rendered_report = render_reports(data)
         log.debug("Report successfully rendered")

--- a/insights_content_template_renderer/logging_sentry.py
+++ b/insights_content_template_renderer/logging_sentry.py
@@ -1,0 +1,33 @@
+"""Sentry SDK configuration and utility functions."""
+
+import logging
+import os
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+
+def get_event_level():
+    """Get level of events to monitor (errors only, or error and warnings)."""
+    if os.environ.get("SENTRY_CATCH_WARNINGS", False):
+        return logging.WARNING
+    return logging.ERROR
+
+
+def init_sentry(
+        dsn=os.environ.get("SENTRY_DSN", None),
+        transport=None,
+        environment=os.environ.get("SENTRY_ENVIRONMENT", None)):
+    """Configure and initialize sentry SDK for this project."""
+    if dsn:
+        logging.getLogger(__name__).info("Initializing sentry")
+        sentry_logging = LoggingIntegration(level=logging.INFO, event_level=get_event_level())
+
+        sentry_sdk.init(
+            dsn=dsn,
+            ca_certs="/etc/pki/tls/certs/ca-bundle.crt",
+            integrations=[sentry_logging],
+            max_breadcrumbs=15,
+            transport=transport,
+            environment=environment,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ prometheus_fastapi_instrumentator==6.1.0
 requests==2.32.3
 httpx
 doT-js-py==2.0.0
+sentry_sdk[fastapi]
 
 # Logging to Cloudwatch
 boto3


### PR DESCRIPTION
Adding logging to Sentry.

### Testing steps

I tested with:

```
pip3 install -r requirements.txt && pip3 install . && uvicorn insights_content_template_renderer.endpoints:app --log-config logging.yml
```

adding `division_by_zero = 1 / 0` in the `rendered_reports` entrypoint with 
```
export SENTRY_DSN=https://MY_SECRET@glitchtip.devshift.net/93
export SENTRY_ENVIRONMENT=dev
export SENTRY_CATCH_WARNINGS=true
```

and

```
curl -d "@request_data_example.json" -H "Content-Type: application/json" -X POST http://127.0.0.1:8000/v1/rendered_reports
```

but I don't see any issues in https://glitchtip.devshift.net/ccx/issues?project=93