### PR TITLE
Update renovate.json configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,37 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "pip_requirements": {
-    "packageRules": [
-      "enabled": true,
+  "packageRules": [
+    {
+      "matchDatasources": ["pypi"],
+      "groupName": "Python dependencies",
+      "groupSlug": "python-deps",
       "separateMajorMinor": false,
-      "groupName": "all dependencies"
-    ]
-  }
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "matchManagers": ["pre-commit"],
+      "groupName": "Pre-commit hooks",
+      "groupSlug": "pre-commit-hooks",
+      "separateMajorMinor": false,
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies",
+      "groupSlug": "go-deps",
+      "separateMajorMinor": false,
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "separateMajorMinor": false,
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Standardize Renovate configuration to match the base configuration from `insights-results-aggregator`
- Enable automerge and platformAutomerge for all dependency types
- Group updates by dependency type (Python, Go, pre-commit hooks, GitHub Actions)

## Changes
This PR updates the `renovate.json` file to adopt a unified configuration that:
- Groups Python dependencies (PyPI) together with automerge enabled
- Groups pre-commit hooks together with automerge enabled  
- Groups Go dependencies together with automerge enabled
- Groups GitHub Actions together with automerge enabled
- Disables major/minor version separation for cleaner PRs

## Benefits
- Reduces manual review overhead by enabling automerge for routine dependency updates
- Improves consistency across all repositories in the organization
- Better organization of dependency updates through grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)